### PR TITLE
feat/Lap segregation

### DIFF
--- a/CsvData.cs
+++ b/CsvData.cs
@@ -129,18 +129,14 @@ public class CsvData
         set => _listLon = value;
     }
 
-    //private List<Tuple<double, double>> _listLatLon = new List<Tuple<double, double>>();
-    //public List<Tuple<double, double>> ListLatLon
-    //{
-    //    get => _listLatLon;
-    //    set => _listLatLon = value;
-    //}
-
-    private List<int> _listLapCount = new List<int>();
-    public List<int> ListLapCount
+    /// <summary>
+    /// Key = lap itself | Value = hertz value at the start of that lap
+    /// </summary>
+    private Dictionary<int, double> _dictLapCount = new Dictionary<int, double>();
+    public Dictionary<int, double> DictLapCount
     {
-        get => _listLapCount;
-        set => _listLapCount = value;
+        get => _dictLapCount;
+        set => _dictLapCount = value;
     }
     #endregion
 
@@ -153,6 +149,7 @@ public class CsvData
         using (StreamReader reader = new StreamReader(filePath))
         {
             int lineCounter = 1;
+            string previousLapCounter = "-1";
 
             while (!reader.EndOfStream)
             {
@@ -189,10 +186,19 @@ public class CsvData
                     _listLambdaRatio.Add(double.Parse(values[9]));
                     _listOilTemperature.Add(double.Parse(values[10]));
                     _listOilPressure.Add(double.Parse(values[11]));
-                    //_listLatLon.Add(new Tuple<double, double>(double.Parse(values[12]), double.Parse(values[13])));
                     _listLat.Add(double.Parse(values[12]));
                     _listLon.Add(double.Parse(values[13]));
-                    _listLapCount.Add(int.Parse(values[14]));
+
+                    if (!previousLapCounter.Equals(values[14]))
+                    {
+                        _dictLapCount.Add(int.Parse(values[14]), double.Parse(values[0]));
+                        previousLapCounter = values[14];
+
+                        // TODO - fix this hack
+                        // Default first one to 0.1 hertz start, works better with the chart
+                        if (_dictLapCount.Count == 1)
+                            _dictLapCount[0] = 0.1;
+                    }
                 }
             }
         }

--- a/CsvData.cs
+++ b/CsvData.cs
@@ -115,18 +115,11 @@ public class CsvData
         set => _listOilPressure = value;
     }
 
-    private List<double> _listLat = new List<double>();
-    public List<double> ListLat
+    private Dictionary<double, (double, double)> _dictLatLon = new Dictionary<double, (double, double)>();
+    public Dictionary<double, (double, double)> DictLatLon
     {
-        get => _listLat;
-        set => _listLat = value;
-    }
-
-    private List<double> _listLon = new List<double>();
-    public List<double> ListLon
-    {
-        get => _listLon;
-        set => _listLon = value;
+        get => _dictLatLon;
+        set => _dictLatLon = value;
     }
 
     /// <summary>
@@ -187,8 +180,8 @@ public class CsvData
                     _listLambdaRatio.Add(double.Parse(values[9]));
                     _listOilTemperature.Add(double.Parse(values[10]));
                     _listOilPressure.Add(double.Parse(values[11]));
-                    _listLat.Add(double.Parse(values[12]));
-                    _listLon.Add(double.Parse(values[13]));
+                    
+                    _dictLatLon.Add(double.Parse(values[0]), (double.Parse(values[12]), double.Parse(values[13])));
 
                     if (!previousLapCounter.Equals(values[14]))
                     {

--- a/CsvData.cs
+++ b/CsvData.cs
@@ -130,13 +130,14 @@ public class CsvData
     }
 
     /// <summary>
-    /// Key = lap itself | Value = hertz value at the start of that lap
+    /// [Key] = lap itself
+    /// [Value] = hertz value at the start & end of that lap
     /// </summary>
-    private Dictionary<int, double> _dictLapCount = new Dictionary<int, double>();
-    public Dictionary<int, double> DictLapCount
+    private Dictionary<int, (double, double)> _dictLapData = new Dictionary<int, (double, double)>();
+    public Dictionary<int, (double, double)> DictLapData
     {
-        get => _dictLapCount;
-        set => _dictLapCount = value;
+        get => _dictLapData;
+        set => _dictLapData = value;
     }
     #endregion
 
@@ -191,16 +192,29 @@ public class CsvData
 
                     if (!previousLapCounter.Equals(values[14]))
                     {
-                        _dictLapCount.Add(int.Parse(values[14]), double.Parse(values[0]));
+                        _dictLapData.Add(int.Parse(values[14]), (double.Parse(values[0]), 0.0));
                         previousLapCounter = values[14];
 
                         // TODO - fix this hack
                         // Default first one to 0.1 hertz start, works better with the chart
-                        if (_dictLapCount.Count == 1)
-                            _dictLapCount[0] = 0.1;
+                        if (_dictLapData.Count == 1)
+                            _dictLapData[0] = (0.1, 0.0);
                     }
                 }
             }
+        }
+
+        // Now fill in the end lap hertz
+        for (int i = 0; i < _dictLapData.Count; i++)
+        {
+            var currVal = _dictLapData[i];
+
+            if (i != _dictLapData.Count - 1)
+                currVal.Item2 = Math.Round(_dictLapData[i + 1].Item1 - 0.1, 1);
+            else
+                currVal.Item2 = _listHertzTime.Last();
+
+            _dictLapData[i] = currVal;
         }
     }
 

--- a/Forms/ChartForm.Designer.cs
+++ b/Forms/ChartForm.Designer.cs
@@ -44,6 +44,9 @@
             lbl_MaxOilTemp = new Label();
             grp_MaxOilPressure = new GroupBox();
             lbl_MaxOilPressure = new Label();
+            btn_Lap1 = new Button();
+            btn_Lap2 = new Button();
+            groupBox1 = new GroupBox();
             ((System.ComponentModel.ISupportInitialize)chart1).BeginInit();
             grp_Gear.SuspendLayout();
             grp_MaxRpm.SuspendLayout();
@@ -53,6 +56,7 @@
             grp_MaxIAT.SuspendLayout();
             grp_MaxOilTemp.SuspendLayout();
             grp_MaxOilPressure.SuspendLayout();
+            groupBox1.SuspendLayout();
             SuspendLayout();
             // 
             // chart1
@@ -67,9 +71,6 @@
             chart1.TabIndex = 0;
             chart1.Text = "chart1";
             chart1.MouseClick += chart1_MouseClick;
-            //chart1.MouseDown += chart1_MouseDown;
-            //chart1.MouseMove += chart1_MouseMove;
-            //chart1.MouseUp += chart1_MouseUp;
             chart1.MouseWheel += chart1_MouseWheelMove;
             // 
             // lbl_Gear
@@ -235,11 +236,43 @@
             lbl_MaxOilPressure.TabIndex = 1;
             lbl_MaxOilPressure.Text = "---";
             // 
+            // btn_Lap1
+            // 
+            btn_Lap1.Location = new Point(6, 16);
+            btn_Lap1.Name = "btn_Lap1";
+            btn_Lap1.Size = new Size(75, 23);
+            btn_Lap1.TabIndex = 6;
+            btn_Lap1.Text = "Lap 1";
+            btn_Lap1.UseVisualStyleBackColor = true;
+            btn_Lap1.Click += btn_Lap1_Click;
+            // 
+            // btn_Lap2
+            // 
+            btn_Lap2.Location = new Point(6, 43);
+            btn_Lap2.Name = "btn_Lap2";
+            btn_Lap2.Size = new Size(75, 23);
+            btn_Lap2.TabIndex = 7;
+            btn_Lap2.Text = "Lap 2";
+            btn_Lap2.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            groupBox1.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+            groupBox1.Controls.Add(btn_Lap1);
+            groupBox1.Controls.Add(btn_Lap2);
+            groupBox1.Location = new Point(86, 380);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Size = new Size(111, 66);
+            groupBox1.TabIndex = 4;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Gear";
+            // 
             // ChartForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1075, 450);
+            Controls.Add(groupBox1);
             Controls.Add(grp_MaxOilPressure);
             Controls.Add(grp_MaxOilTemp);
             Controls.Add(grp_MaxIAT);
@@ -267,6 +300,7 @@
             grp_MaxOilTemp.PerformLayout();
             grp_MaxOilPressure.ResumeLayout(false);
             grp_MaxOilPressure.PerformLayout();
+            groupBox1.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -288,5 +322,8 @@
         private Label lbl_MaxOilTemp;
         private GroupBox grp_MaxOilPressure;
         private Label lbl_MaxOilPressure;
+        private Button btn_Lap1;
+        private Button btn_Lap2;
+        private GroupBox groupBox1;
     }
 }

--- a/Forms/ChartForm.Designer.cs
+++ b/Forms/ChartForm.Designer.cs
@@ -44,9 +44,6 @@
             lbl_MaxOilTemp = new Label();
             grp_MaxOilPressure = new GroupBox();
             lbl_MaxOilPressure = new Label();
-            btn_Lap1 = new Button();
-            btn_Lap2 = new Button();
-            groupBox1 = new GroupBox();
             ((System.ComponentModel.ISupportInitialize)chart1).BeginInit();
             grp_Gear.SuspendLayout();
             grp_MaxRpm.SuspendLayout();
@@ -56,7 +53,6 @@
             grp_MaxIAT.SuspendLayout();
             grp_MaxOilTemp.SuspendLayout();
             grp_MaxOilPressure.SuspendLayout();
-            groupBox1.SuspendLayout();
             SuspendLayout();
             // 
             // chart1
@@ -236,43 +232,11 @@
             lbl_MaxOilPressure.TabIndex = 1;
             lbl_MaxOilPressure.Text = "---";
             // 
-            // btn_Lap1
-            // 
-            btn_Lap1.Location = new Point(6, 16);
-            btn_Lap1.Name = "btn_Lap1";
-            btn_Lap1.Size = new Size(75, 23);
-            btn_Lap1.TabIndex = 6;
-            btn_Lap1.Text = "Lap 1";
-            btn_Lap1.UseVisualStyleBackColor = true;
-            btn_Lap1.Click += btn_Lap1_Click;
-            // 
-            // btn_Lap2
-            // 
-            btn_Lap2.Location = new Point(6, 43);
-            btn_Lap2.Name = "btn_Lap2";
-            btn_Lap2.Size = new Size(75, 23);
-            btn_Lap2.TabIndex = 7;
-            btn_Lap2.Text = "Lap 2";
-            btn_Lap2.UseVisualStyleBackColor = true;
-            // 
-            // groupBox1
-            // 
-            groupBox1.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
-            groupBox1.Controls.Add(btn_Lap1);
-            groupBox1.Controls.Add(btn_Lap2);
-            groupBox1.Location = new Point(86, 380);
-            groupBox1.Name = "groupBox1";
-            groupBox1.Size = new Size(111, 66);
-            groupBox1.TabIndex = 4;
-            groupBox1.TabStop = false;
-            groupBox1.Text = "Gear";
-            // 
             // ChartForm
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(1075, 450);
-            Controls.Add(groupBox1);
             Controls.Add(grp_MaxOilPressure);
             Controls.Add(grp_MaxOilTemp);
             Controls.Add(grp_MaxIAT);
@@ -300,7 +264,6 @@
             grp_MaxOilTemp.PerformLayout();
             grp_MaxOilPressure.ResumeLayout(false);
             grp_MaxOilPressure.PerformLayout();
-            groupBox1.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -322,8 +285,5 @@
         private Label lbl_MaxOilTemp;
         private GroupBox grp_MaxOilPressure;
         private Label lbl_MaxOilPressure;
-        private Button btn_Lap1;
-        private Button btn_Lap2;
-        private GroupBox groupBox1;
     }
 }

--- a/Forms/ChartForm.Designer.cs
+++ b/Forms/ChartForm.Designer.cs
@@ -116,9 +116,9 @@
             // chart_TrackMap
             // 
             chart_TrackMap.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-            chart_TrackMap.Location = new Point(770, 146);
+            chart_TrackMap.Location = new Point(875, 250);
             chart_TrackMap.Name = "chart_TrackMap";
-            chart_TrackMap.Size = new Size(300, 300);
+            chart_TrackMap.Size = new Size(200, 200);
             chart_TrackMap.TabIndex = 5;
             chart_TrackMap.Text = "chart_TrackMap";
             // 

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -17,7 +17,7 @@ public partial class ChartForm : Form
         {
             _csvData = csvData;
             InitialChartSetup();
-            MapDataPointsToChart();
+            MapDataPointsToChart(9999);
             DrawTrackMap();
         }
     }
@@ -136,11 +136,12 @@ public partial class ChartForm : Form
             loadThisHertzRange = _csvData.ListHertzTime.GetRange(startIndex, endIndex - startIndex + 1);
         }
 
-        // Cleanup to reload
+        // Cleanup for changing chart
         while (chart1.Series.Count > 0)
         {
             chart1.Series.RemoveAt(0);
-        }
+        while (chart1.Legends.Count > 0)
+            chart1.Legends.RemoveAt(0);
 
         double[] GetRelevantDataForThisHertzRange(double[] fullList)
         {
@@ -174,6 +175,8 @@ public partial class ChartForm : Form
                     ForeColor = Color.White,
                     BackColor = Color.Transparent
                 };
+
+                chart1.Legends.Add(legend);
 
                 // Create series
                 Series series = new Series

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -141,7 +141,7 @@ public partial class ChartForm : Form
             chart1.Series.RemoveAt(0);
         while (chart1.Legends.Count > 0)
             chart1.Legends.RemoveAt(0);
-        if (previousMarkerDataPoint >= 0)
+        if (chart_TrackMap.Series.Any(x => x.Name == "DataMarker"))
         {
             Series removeSeries = chart_TrackMap.Series[1];
             chart_TrackMap.Series.Remove(removeSeries);

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -112,7 +112,7 @@ public partial class ChartForm : Form
         #endregion
     }
 
-    private void MapDataPointsToChart(int displayThisSpecificLap)
+    public void MapDataPointsToChart(int displayThisSpecificLap)
     {
         // Load in lap 1's data points
         // Re-render the chart to suit
@@ -237,7 +237,7 @@ public partial class ChartForm : Form
         
     }
 
-    private void MapDataPointsToChart()
+    public void MapDataPointsToChart()
     {
         int counter = 1;
         double[] hertzTimeArr = _csvData.ListHertzTime.ToArray();
@@ -756,13 +756,6 @@ public partial class ChartForm : Form
                     ca.AxisX.StripLines.Remove(ca.AxisX.StripLines[0]);
             }
         }
-    }
-
-    private void btn_Lap1_Click(object sender, EventArgs e)
-    {
-        // TODO: do a dynamically built combobox based on lapcount
-        int buttonClickValue = 2;
-        MapDataPointsToChart(buttonClickValue);
     }
 
 }

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -543,7 +543,7 @@ public partial class ChartForm : Form
                 series.ChartType = SeriesChartType.Point;
                 series.Points.AddXY(lon, lat);
                 series.Points[0].MarkerColor = Color.Red;
-                series.Points[0].MarkerSize = 20;
+                series.Points[0].MarkerSize = 15;
                 series.Points[0].MarkerStyle = MarkerStyle.Circle;
                 series.Points[0].Color = Color.Red;
 

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -437,54 +437,6 @@ public partial class ChartForm : Form
         chart_TrackMap.Series.Add(series);
     }
 
-    private void MoveTrackMapCurrentPosition(double lat, double lon)
-    {
-        // First clear the previous marker
-        //if (previousMarkerDataPoint >= 0)
-        //{
-        //    DataPoint point = chart_TrackMap.Series[0].Points[previousMarkerDataPoint];
-        //    point.MarkerColor = default;
-        //    point.MarkerSize = default;
-        //    point.MarkerStyle = default;
-        //}
-
-        for (var i = 0; i < chart_TrackMap.Series[0].Points.Count; i++)
-        {
-            DataPoint point = chart_TrackMap.Series[0].Points[i];
-            
-            if (point.XValue == lon && point.YValues.FirstOrDefault() == lat)
-            {
-                // TODO: This works but the blue line goes through circle
-                //point.MarkerColor = Color.Red;
-                //point.MarkerSize = 20;
-                //point.MarkerStyle = MarkerStyle.Circle;
-
-                //point.Color = Color.Red;
-
-                // TODO: This is the shitty workaround
-                // Remove the current series if it exists
-                if (previousMarkerDataPoint >= 0 && chart_TrackMap.Series.Any(x => x.Name == "DataMarker"))
-                {
-                    Series removeSeries = chart_TrackMap.Series[1];
-                    chart_TrackMap.Series.Remove(removeSeries);
-                }
-
-                Series series = new Series("DataMarker");
-                series.ChartType = SeriesChartType.Point;
-                series.Points.AddXY(lon, lat);
-                series.Points[0].MarkerColor = Color.Red;
-                series.Points[0].MarkerSize = 20;
-                series.Points[0].MarkerStyle = MarkerStyle.Circle;
-                series.Points[0].Color = Color.Red;
-
-                chart_TrackMap.Series.Add(series);
-
-                previousMarkerDataPoint = i;
-                break;
-            }
-        }
-    }
-
     private void DoCurrentCursorPositionDataEvalution(object sender, MouseEventArgs e)
     {
         if (chart1 != null && e.X > 0)
@@ -550,6 +502,54 @@ public partial class ChartForm : Form
             //    .ToList()
             //    .ForEach(x => x.LegendText = x.Name + " = " + yValue.ToString());
             //double yValue = Math.Round(chart.ChartAreas[series.ChartArea].AxisY.PixelPositionToValue(e.Y), 2);
+        }
+    }
+
+    private void MoveTrackMapCurrentPosition(double lat, double lon)
+    {
+        // First clear the previous marker
+        //if (previousMarkerDataPoint >= 0)
+        //{
+        //    DataPoint point = chart_TrackMap.Series[0].Points[previousMarkerDataPoint];
+        //    point.MarkerColor = default;
+        //    point.MarkerSize = default;
+        //    point.MarkerStyle = default;
+        //}
+
+        for (var i = 0; i < chart_TrackMap.Series[0].Points.Count; i++)
+        {
+            DataPoint point = chart_TrackMap.Series[0].Points[i];
+
+            if (point.XValue == lon && point.YValues.FirstOrDefault() == lat)
+            {
+                // TODO: This works but the blue line goes through circle
+                //point.MarkerColor = Color.Red;
+                //point.MarkerSize = 20;
+                //point.MarkerStyle = MarkerStyle.Circle;
+
+                //point.Color = Color.Red;
+
+                // TODO: This is the shitty workaround
+                // Remove the current series if it exists
+                if (previousMarkerDataPoint >= 0 && chart_TrackMap.Series.Any(x => x.Name == "DataMarker"))
+                {
+                    Series removeSeries = chart_TrackMap.Series[1];
+                    chart_TrackMap.Series.Remove(removeSeries);
+                }
+
+                Series series = new Series("DataMarker");
+                series.ChartType = SeriesChartType.Point;
+                series.Points.AddXY(lon, lat);
+                series.Points[0].MarkerColor = Color.Red;
+                series.Points[0].MarkerSize = 20;
+                series.Points[0].MarkerStyle = MarkerStyle.Circle;
+                series.Points[0].Color = Color.Red;
+
+                chart_TrackMap.Series.Add(series);
+
+                previousMarkerDataPoint = i;
+                break;
+            }
         }
     }
 

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -249,174 +249,30 @@ public partial class ChartForm : Form
         chart1.ChartAreas["ChartArea4"].AxisY.Interval = 10;
 
 
-    }
-
-    public void MapDataPointsToChart()
+        if (loadAllLaps)
     {
-        int counter = 1;
-        double[] hertzTimeArr = _csvData.ListHertzTime.ToArray();
-
-        void DoDataPoints(List<ChartDataConfig> chartDataConfigs)
-        {
-            foreach (ChartDataConfig chartDataConfig in chartDataConfigs)
-            {
-                CsvData.DataValues enumValue = (CsvData.DataValues)chartDataConfig.DataPoint;
-                if (enumValue == CsvData.DataValues.Empty)
-                    continue;
-
-                ChartDataConfig.Colours colour = (ChartDataConfig.Colours)chartDataConfig.LineColour;
-
-                // Create Legends
-                Legend legend = new Legend
-                {
-                    Name = "Legend:" + counter.ToString() + ":" + enumValue.ToString(),
-                    DockedToChartArea = "ChartArea" + counter.ToString(),
-                    Docking = Docking.Left,
-                    IsDockedInsideChartArea = true,
-                    LegendStyle = LegendStyle.Row,
-                    ForeColor = Color.White,
-                    BackColor = Color.Transparent
-                };
-
-                chart1.Legends.Add(legend);
-
-
-                // Create series
-                Series series = new Series
-                {
-                    Name = "Series:" + counter.ToString() + ":" + enumValue.ToString(),
-                    LegendText = enumValue.ToString(),
-                    IsValueShownAsLabel = false,
-                    ChartArea = "ChartArea" + counter.ToString(),
-                    Legend = "Legend:" + counter.ToString() + ":" + enumValue.ToString(),
-                    Color = ColorTranslator.FromHtml(ChartDataConfig.GetColourValue(colour)),
-                    ChartType = SeriesChartType.FastLine,
-                    XValueType = ChartValueType.Double
-                };
-
-                series.Points.DataBindXY(hertzTimeArr, _csvData.GetDataPointsList(enumValue));
-                chart1.ChartAreas["ChartArea" + counter.ToString()].AxisY.Interval = _csvData.GetDataPointsInterval(enumValue);
-                chart1.Series.Add(series);
-            }
-
-            counter++;
-        }
-
-        DoDataPoints(AppSettings.Chart1DataPoints);
-        DoDataPoints(AppSettings.Chart2DataPoints);
-        DoDataPoints(AppSettings.Chart3DataPoints);
-        DoDataPoints(AppSettings.Chart4DataPoints);
-
-        #region Lat/Lon stuff
-        Series seriesLat = new Series()
-        {
-            Name = "Series:4:Lat",
-            ChartArea = "ChartArea4",
-            XValueType = ChartValueType.Double
-        };
-        Series seriesLon = new Series()
-        {
-            Name = "Series:4:Lon",
-            ChartArea = "ChartArea4",
-            XValueType = ChartValueType.Double
-        };
-
-        double[] listLat = _csvData.ListLat.ToArray();
-        double[] listLon = _csvData.ListLon.ToArray();
-        seriesLat.Points.DataBindXY(hertzTimeArr, listLat);
-        seriesLon.Points.DataBindXY(hertzTimeArr, listLon);
-        chart1.Series.Add(seriesLat);
-        chart1.Series.Add(seriesLon);
-        #endregion
-
-        /* TODO: Fix this properly
-         * Using it so we can reference the gear position for the label at the bottom of the screen,
-         * whilst still getitng relevant position based on chart position click
-         */
-        if (chart1.Series.Any(x => x.Name == "Series4:4:Gear"))
-            chart1.Series["Series:4:Gear"].Enabled = false;
-        chart1.Series["Series:4:Lat"].Enabled = false;
-        chart1.Series["Series:4:Lon"].Enabled = false;
-        chart1.ChartAreas["ChartArea4"].AxisY.Interval = 10;
-
-
-        #region --- Lap segregation ---
-        if (false)
-        {
-            //List<Tuple<string, int>> lapList = new List<Tuple<string, int>>();
-            //for (int i = 1; i < csvData.ListLapCount.Count; i++)
-            //{
-            //    if (csvData.ListLapCount[i - 1] != csvData.ListLapCount[i])
-            //        lapList.Add(new Tuple<string, int>(csvData.ListHertzTime[i], csvData.ListLapCount[i]));
-            //}
-
-            //foreach (ChartArea ca in chart1.ChartAreas)
-            //{
-            //    foreach (var lap in lapList)
-            //    {
-            //        ca.AxisX.StripLines.Add(new StripLine()
-            //        {
-            //            IntervalOffset = Convert.ToDouble(lap.Item1),
-            //            StripWidth = 0,
-            //            BorderColor = Color.Gray,
-            //            BorderWidth = 1,
-            //            BorderDashStyle = ChartDashStyle.Solid,
-            //            Text = "Lap: " + lap.Item2.ToString(),
-            //            ForeColor = Color.Gray
-            //        });
-            //    }
-            //}
-        }
-
-        // TODO: Defaulting the lap segregation manually until the dash can auto handle it correctly
-        if (true)
-        {
-            bool isFinishLine(double min, double max, double current)
-            {
-                return current >= min && current <= max;
-            }
-
-            double thisTrackLatMin = 0;
-            double thisTrackLatMax = 0;
-            double thisTrackLonMin = 0;
-            double thisTrackLonMax = 0;
-
-            switch (_csvData.Track)
-            {
-                case "smsp":
-                    thisTrackLatMin = -33.803825;
-                    thisTrackLatMax = -33.803653;
-                    thisTrackLonMin = 150.870923;
-                    thisTrackLonMax = 150.870962;
-                    break;
-                case "morganpark":
-                    thisTrackLatMin = -28.262069;
-                    thisTrackLatMax = -28.262085;
-                    thisTrackLonMin = 152.036327;
-                    thisTrackLonMax = 152.036430;
-                    break;
-            }
-
-            List<Tuple<double, string>> lapList = new List<Tuple<double, string>>();
-            lapList.Add(new Tuple<double, string>(hertzTimeArr[1], "Out"));
-            for (int i = 0; i < hertzTimeArr.Length; i++)
-            {
-                if (isFinishLine(thisTrackLatMin, thisTrackLatMax, _csvData.ListLat[i]) && isFinishLine(thisTrackLonMin, thisTrackLonMax, _csvData.ListLon[i]))
-                    lapList.Add(new Tuple<double, string>(hertzTimeArr[i], (lapList.Count).ToString()));
-            }
-
             foreach (ChartArea ca in chart1.ChartAreas)
+        {
+                foreach (var lap in _csvData.DictLapData)
             {
-                foreach (var lap in lapList)
-                {
+                    string lapText = "";
+                    int maxLaps = _csvData.DictLapData.Count;
+
+                    if (lap.Key == 0)
+                        lapText = "Out Lap";
+                    else if (lap.Key == maxLaps - 1)
+                        lapText = "In Lap";
+                    else
+                        lapText = "Lap " + lap.Key.ToString();
+
                     ca.AxisX.StripLines.Add(new StripLine()
                     {
-                        IntervalOffset = Convert.ToDouble(lap.Item1),
+                        IntervalOffset = lap.Value.Item1,
                         StripWidth = 0,
                         BorderColor = Color.Gray,
                         BorderWidth = 1,
                         BorderDashStyle = ChartDashStyle.Solid,
-                        Text = "Lap: " + lap.Item2.ToString(),
+                        Text = lapText,
                         ForeColor = Color.Gray,
                         TextOrientation = TextOrientation.Horizontal,
                         TextAlignment = StringAlignment.Near
@@ -424,7 +280,6 @@ public partial class ChartForm : Form
                 }
             }
         }
-        #endregion
 
         foreach (ChartArea ca in chart1.ChartAreas)
         {
@@ -469,6 +324,34 @@ public partial class ChartForm : Form
         lbl_MaxOilTemp.Text = maxOilTemp.ToString();
         lbl_MaxOilPressure.Text = maxOilPressure.ToString();
         #endregion
+
+        // TESTING
+        // TODO: Defaulting the lap segregation manually until the dash can auto handle it correctly
+        // USED this to work out the laps for the data we have, then updated the lap in the data.
+        // It's also testing the GPS stuff for the dash, so maybe handy to keep it somewhere
+        if (false)
+        {
+            double thisTrackLatMin = 0;
+            double thisTrackLatMax = 0;
+            double thisTrackLonMin = 0;
+            double thisTrackLonMax = 0;
+            double previousLat = 0.0;
+            double previousLon = 0.0;
+
+            switch (_csvData.Track)
+            {
+                case "smsp":
+                    thisTrackLatMin = -33.803825;
+                    thisTrackLatMax = -33.803653;
+                    thisTrackLonMin = 150.870923;
+                    thisTrackLonMax = 150.870962;
+                    break;
+                case "morganpark":
+                    thisTrackLatMin = -28.262069;
+                    thisTrackLatMax = -28.262085;
+                    thisTrackLonMin = 152.036327;
+                    thisTrackLonMax = 152.036430;
+                    break;
     }
 
     private void DrawTrackMap()

--- a/Forms/ChartForm.cs
+++ b/Forms/ChartForm.cs
@@ -217,6 +217,7 @@ public partial class ChartForm : Form
             ca.AxisX.Minimum = double.NaN;
             ca.AxisX.Maximum = double.NaN;
             ca.RecalculateAxesScale();
+            ca.AxisX.ScaleView.ZoomReset();
         }
 
         if (chart1.Series.Any(x => x.Name == "Series4:4:Gear"))
@@ -299,7 +300,7 @@ public partial class ChartForm : Form
         lbl_MaxOilPressure.Text = maxOilPressure.ToString();
         #endregion
 
-        // TESTING
+        #region Test code for calculating the laps based on lat/lon
         // TODO: Defaulting the lap segregation manually until the dash can auto handle it correctly
         // USED this to work out the laps for the data we have, then updated the lap in the data.
         // It's also testing the GPS stuff for the dash, so maybe handy to keep it somewhere
@@ -375,6 +376,7 @@ public partial class ChartForm : Form
         //        previousLon = _csvData.ListLon[i];
         //    }
         //}
+        #endregion
     }
 
     private void DrawTrackMap()
@@ -586,6 +588,11 @@ public partial class ChartForm : Form
     /// <param name="e"></param>
     private void chart1_MouseWheelMove(object sender, MouseEventArgs e)
     {
+        /* NOTE
+         * - This is experimental, trying to find the right solution with scaling so it's pleasant to the eye
+         * - So there might be some different iterations commented out, just testing things as I go
+         */
+
         Axis xAxis = chart1.ChartAreas[0].AxisX;
         double zoomScale = 0.1; //0.05
         double currentXMinView = xAxis.ScaleView.ViewMinimum;
@@ -672,7 +679,7 @@ public partial class ChartForm : Form
         }
         catch (Exception ex)
         {
-            Console.WriteLine("ERROR: " + ex);
+            MessageBox.Show("ERROR: " + ex);
         }
     }
 

--- a/Forms/ChartForm.resx
+++ b/Forms/ChartForm.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -85,8 +85,8 @@ namespace WT_DataAnalysis
             // 
             tsmi_LapSelector.Items.AddRange(new object[] { "All Laps" });
             tsmi_LapSelector.Name = "tsmi_LapSelector";
-            tsmi_LapSelector.Size = new Size(121, 23);
-            tsmi_LapSelector.Text = "-- Lap Selection --";
+            tsmi_LapSelector.Size = new Size(80, 23);
+            tsmi_LapSelector.Text = "-- Lap  --";
             tsmi_LapSelector.SelectedIndexChanged += tsmi_LapSelector_SelectedIndexChanged;
             // 
             // ofd_LoadFile

--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -33,9 +33,10 @@ namespace WT_DataAnalysis
             components = new System.ComponentModel.Container();
             menuStrip1 = new MenuStrip();
             tsmi_LoadFile = new ToolStripMenuItem();
-            tsmi_SettingsForm = new ToolStripMenuItem();
             tsmi_ChartForm = new ToolStripMenuItem();
             tsmi_ScatterPlotForm = new ToolStripMenuItem();
+            tsmi_SettingsForm = new ToolStripMenuItem();
+            tsmi_LapSelector = new ToolStripComboBox();
             toolTip1 = new ToolTip(components);
             ofd_LoadFile = new OpenFileDialog();
             menuStrip1.SuspendLayout();
@@ -45,40 +46,48 @@ namespace WT_DataAnalysis
             // 
             menuStrip1.BackColor = Color.FromArgb(45, 45, 45);
             menuStrip1.ForeColor = Color.FromArgb(255, 255, 255);
-            menuStrip1.Items.AddRange(new ToolStripItem[] { tsmi_LoadFile, tsmi_ChartForm, tsmi_ScatterPlotForm, tsmi_SettingsForm });
+            menuStrip1.Items.AddRange(new ToolStripItem[] { tsmi_LoadFile, tsmi_ChartForm, tsmi_ScatterPlotForm, tsmi_SettingsForm, tsmi_LapSelector });
             menuStrip1.Location = new Point(0, 0);
             menuStrip1.Name = "menuStrip1";
-            menuStrip1.Size = new Size(1131, 24);
+            menuStrip1.Size = new Size(1131, 27);
             menuStrip1.TabIndex = 3;
             menuStrip1.Text = "menuStrip1";
             // 
             // tsmi_LoadFile
             // 
             tsmi_LoadFile.Name = "tsmi_LoadFile";
-            tsmi_LoadFile.Size = new Size(66, 20);
+            tsmi_LoadFile.Size = new Size(66, 23);
             tsmi_LoadFile.Text = "Load File";
             tsmi_LoadFile.Click += toolStripMenuItem_Click;
-            // 
-            // tsmi_SettingsForm
-            // 
-            tsmi_SettingsForm.Name = "tsmi_SettingsForm";
-            tsmi_SettingsForm.Size = new Size(61, 20);
-            tsmi_SettingsForm.Text = "Settings";
-            tsmi_SettingsForm.Click += toolStripMenuItem_Click;
             // 
             // tsmi_ChartForm
             // 
             tsmi_ChartForm.Name = "tsmi_ChartForm";
-            tsmi_ChartForm.Size = new Size(83, 20);
+            tsmi_ChartForm.Size = new Size(83, 23);
             tsmi_ChartForm.Text = "Main Charts";
             tsmi_ChartForm.Click += toolStripMenuItem_Click;
             // 
             // tsmi_ScatterPlotForm
             // 
             tsmi_ScatterPlotForm.Name = "tsmi_ScatterPlotForm";
-            tsmi_ScatterPlotForm.Size = new Size(79, 20);
+            tsmi_ScatterPlotForm.Size = new Size(79, 23);
             tsmi_ScatterPlotForm.Text = "Scatter Plot";
             tsmi_ScatterPlotForm.Click += toolStripMenuItem_Click;
+            // 
+            // tsmi_SettingsForm
+            // 
+            tsmi_SettingsForm.Name = "tsmi_SettingsForm";
+            tsmi_SettingsForm.Size = new Size(61, 23);
+            tsmi_SettingsForm.Text = "Settings";
+            tsmi_SettingsForm.Click += toolStripMenuItem_Click;
+            // 
+            // tsmi_LapSelector
+            // 
+            tsmi_LapSelector.Items.AddRange(new object[] { "All Laps" });
+            tsmi_LapSelector.Name = "tsmi_LapSelector";
+            tsmi_LapSelector.Size = new Size(121, 23);
+            tsmi_LapSelector.Text = "-- Lap Selection --";
+            tsmi_LapSelector.SelectedIndexChanged += tsmi_LapSelector_SelectedIndexChanged;
             // 
             // ofd_LoadFile
             // 
@@ -112,5 +121,6 @@ namespace WT_DataAnalysis
         private ToolStripMenuItem tsmi_ChartForm;
         private ToolStripMenuItem tsmi_ScatterPlotForm;
         private ToolStripMenuItem tsmi_SettingsForm;
+        private ToolStripComboBox tsmi_LapSelector;
     }
 }

--- a/Forms/MainForm.Designer.cs
+++ b/Forms/MainForm.Designer.cs
@@ -86,7 +86,7 @@ namespace WT_DataAnalysis
             tsmi_LapSelector.Items.AddRange(new object[] { "All Laps" });
             tsmi_LapSelector.Name = "tsmi_LapSelector";
             tsmi_LapSelector.Size = new Size(80, 23);
-            tsmi_LapSelector.Text = "-- Lap  --";
+            tsmi_LapSelector.SelectedIndex = 0;
             tsmi_LapSelector.SelectedIndexChanged += tsmi_LapSelector_SelectedIndexChanged;
             // 
             // ofd_LoadFile

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -56,7 +56,7 @@ public MainForm()
 
     private void SetupLapCountComboBox()
     {
-        int maxLaps = CsvData.DictLapCount.Count;
+        int maxLaps = CsvData.DictLapData.Count;
         for (int i = 0; i < maxLaps; i++)
         {
             string item = "";
@@ -190,7 +190,7 @@ private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         if (tsmi_LapSelector.SelectedItem != "All Laps")
             selectedLap = tsmi_LapSelector.Items.IndexOf(tsmi_LapSelector.SelectedItem) - 1;
         else
-            selectedLap = 0000; // TODO: Hacky, fix one decade
+            selectedLap = 9999; // TODO: Hacky, fix one decade
 
         _ChartForm.MapDataPointsToChart(selectedLap);
     }

--- a/Forms/MainForm.cs
+++ b/Forms/MainForm.cs
@@ -39,6 +39,7 @@ public MainForm()
             string fileName = "";
 
             CsvData.ReadCsvData(fileName);
+            SetupLapCountComboBox();
 
             _ChartForm = new ChartForm(CsvData)
             {
@@ -52,6 +53,24 @@ public MainForm()
             //OpenScatterPlotForm();
     }
 }
+
+    private void SetupLapCountComboBox()
+    {
+        int maxLaps = CsvData.DictLapCount.Count;
+        for (int i = 0; i < maxLaps; i++)
+        {
+            string item = "";
+
+            if (i == 0)
+                item = "Out Lap";
+            else if (i == maxLaps - 1)
+                item = "In Lap";
+            else
+                item = "Lap " + i.ToString();
+            
+            tsmi_LapSelector.Items.Add(item);
+        }
+    }
 
     private void OpenChartForm()
 {
@@ -132,7 +151,10 @@ private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
                         Text = "WillTech - Data Analysis (" + ofd_LoadFile.SafeFileName + ")";
 
                         if (!string.IsNullOrEmpty(ofd_LoadFile.FileName))
+                        {
                             CsvData.ReadCsvData(ofd_LoadFile.FileName);
+                            SetupLapCountComboBox();
+                        }
 
                         _ChartForm = new ChartForm(CsvData)
                         {
@@ -160,5 +182,16 @@ private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
                 OpenSettingsForm();
                 break;
         }
+    }
+
+    private void tsmi_LapSelector_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        int selectedLap = 0;
+        if (tsmi_LapSelector.SelectedItem != "All Laps")
+            selectedLap = tsmi_LapSelector.Items.IndexOf(tsmi_LapSelector.SelectedItem) - 1;
+        else
+            selectedLap = 0000; // TODO: Hacky, fix one decade
+
+        _ChartForm.MapDataPointsToChart(selectedLap);
     }
 }


### PR DESCRIPTION
The application will recognise the lap for each bit of data, and allow the user to select a specific lap, including the Out or In laps. On selection, the chart view will reload to that specific lap for deeper analysis.

It's working quite well I think, response is actually better than I thought it would be with a 8 lap dataset (10hz, 2min 15sec lap times).

If zoomed in and a lap change is selected, it'll reset the zoom to default.