### PR TITLE
refactor/Lap timing

### DIFF
--- a/WT-DataAnalysis-DatalogReview/CustomFormComponents/PanelValueDisplay.cs
+++ b/WT-DataAnalysis-DatalogReview/CustomFormComponents/PanelValueDisplay.cs
@@ -1,0 +1,63 @@
+﻿namespace WT_DataAnalysis_DatalogReview.CustomFormComponents;
+
+public static class PanelValueDisplay
+{
+    private static Panel _panel;
+    private static Label _lblName;
+    private static Label _lblValue;
+
+    public static Panel CreatePanel(string controlName)
+    {
+        /* TODO
+         * 
+         * Spec:
+         * - Dynamically with the width, decide on the label widths, height, size etc
+         * 
+         * Labels default margin left/right: 3px
+         */
+
+        _panel = new Panel()
+        {
+            Name = "VD_Panel_" + controlName.Replace(" ", ""),
+            Height = 50,
+            Dock = DockStyle.Top
+        };
+        _panel.Paint += Panel_CustomBorder;
+
+        _lblName = new Label()
+        {
+            Text = controlName,
+            Name = "LabelName",
+            //BackColor = Color.Blue, // Test-Designing
+            Location = new Point(2, 2),
+            Size = new Size(250, 44),
+            Font = new Font("Segoe UI", 20),
+            ForeColor = Color.White,
+        };
+
+        _lblValue = new Label()
+        {
+            Name = "LabelValue",
+            //BackColor = Color.Red, // Test-Designing
+            Location = new Point(235, 2),
+            Size = new Size(160, 44),
+            Margin = new Padding(0),
+            Font = new Font("Segoe UI", 22),
+            ForeColor = Color.White,
+        };
+
+        _panel.Controls.Add(_lblValue);
+        _panel.Controls.Add(_lblName);
+        
+        return _panel;
+    }
+
+    private static void Panel_CustomBorder(object sender, PaintEventArgs e)
+    {
+        using (Pen pen = new Pen(Color.White, 2))
+        {
+            pen.Alignment = System.Drawing.Drawing2D.PenAlignment.Inset;
+            e.Graphics.DrawRectangle(pen, 0, 0, _panel.Width - 1, _panel.Height - 1);
+        }
+    }
+}

--- a/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
+++ b/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
@@ -385,7 +385,7 @@ public class CsvData
             }
         }
 
-        // Now fill in the end lap hertz
+        // Contains the min/max hertz for each lap
         for (int i = 0; i < _dictLapData.Count; i++)
         {
             var currVal = _dictLapData[i];
@@ -397,6 +397,27 @@ public class CsvData
 
             _dictLapData[i] = currVal;
         }
+
+        // Lap Timing - Work out the derived data values
+        // TODO: This is dirty, do 'properly' one day
+        for (int i = 0; i <= _listHertzTime.Count - 1; i++)
+        {
+            var currentLapIndex = _listLapIndex[i];
+
+            if (i == _listHertzTime.Count - 1)
+            {
+                _dictLapTimes.Add(currentLapIndex, _listSessionStartTimeMs[i] - _listLapStartTimeMs[i]);
+                break;
+            }
+
+            if (currentLapIndex < _listLapIndex[i + 1])
+                _dictLapTimes.Add(currentLapIndex, _listSessionStartTimeMs[i - 1] - _listLapStartTimeMs[i - 1]);
+        }
+
+        var bestLap = _dictLapTimes
+                        .OrderBy(x => x.Value)
+                        .First();
+        _bestLapTime = (bestLap.Key, bestLap.Value);
     }
 
     public double[] GetDataPointsList(DataValues dataValue)

--- a/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
+++ b/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
@@ -480,6 +480,12 @@ public class CsvData
                 return ListEthanolInput2.ToArray();
             case DataValues.EthanolInput3:
                 return ListEthanolInput3.ToArray();
+            case DataValues.SessionStartTimeMs:
+                return ListSessionStartTimeMs.ToArray();
+            case DataValues.LapIndex:
+                return ListLapIndex.ToArray();
+            case DataValues.LapStartTimeMs:
+                return ListLapStartTimeMs.ToArray();
             default:
                 return null;
         }
@@ -545,6 +551,12 @@ public class CsvData
                 return ListEthanolInput2.Max();
             case 27:
                 return ListEthanolInput3.Max();
+            case 28:
+                return ListSessionStartTimeMs.Max();
+            case 29:
+                return ListLapIndex.Max();
+            case 30:
+                return ListLapStartTimeMs.Max();
             default:
                 return 0;
         }
@@ -610,6 +622,12 @@ public class CsvData
                 return ListEthanolInput2[lookupIndex];
             case 27:
                 return ListEthanolInput3[lookupIndex];
+            case 28:
+                return ListSessionStartTimeMs[lookupIndex];
+            case 29:
+                return ListLapIndex[lookupIndex];
+            case 30:
+                return ListLapStartTimeMs[lookupIndex];
             default:
                 return 0;
         }
@@ -686,6 +704,9 @@ public class CsvData
         Analog7 = 25,
         EthanolInput1 = 26,
         EthanolInput2 = 27,
-        EthanolInput3 = 28
+        EthanolInput3 = 28,
+        SessionStartTimeMs = 29,
+        LapIndex = 30,
+        LapStartTimeMs = 31
     }
 }

--- a/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
+++ b/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
@@ -244,6 +244,7 @@ public class CsvData
     }
 
     /// <summary>
+    /// More so a helper collection, contains each lap with their min/max hertz time for start/finish of each lap
     /// [Key] = lap itself
     /// [Value] = hertz value at the start & end of that lap
     /// </summary>
@@ -326,11 +327,10 @@ public class CsvData
                 {
                     try
                     {
-                        // Debugging
+                        // For debugging
                         //if (values[0] == "00.1")
-                        //{
                         //    int i = 0;
-                        //}
+                        
                         _listHertzTime.Add(double.Parse(values[0]));
                         _listRpm.Add(double.Parse(values[1]));
                         _listSpeed.Add(double.Parse(values[2]));

--- a/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
+++ b/WT-DataAnalysis-DatalogReview/Models/CsvData.cs
@@ -253,6 +253,41 @@ public class CsvData
         get => _dictLapData;
         set => _dictLapData = value;
     }
+
+    private List<double> _listSessionStartTimeMs = new List<double>();
+    public List<double> ListSessionStartTimeMs
+    {
+        get => _listSessionStartTimeMs;
+        set => _listSessionStartTimeMs = value;
+    }
+
+    private List<double> _listLapIndex = new List<double>();
+    public List<double> ListLapIndex
+    {
+        get => _listLapIndex;
+        set => _listLapIndex = value;
+    }
+
+    private List<double> _listLapStartTimeMs = new List<double>();
+    public List<double> ListLapStartTimeMs
+    {
+        get => _listLapStartTimeMs;
+        set => _listLapStartTimeMs = value;
+    }
+
+    private Dictionary<double, double> _dictLapTimes = new Dictionary<double, double>();
+    public Dictionary<double, double> DictLapTimes
+    {
+        get => _dictLapTimes;
+        set => _dictLapTimes = value;
+    }
+
+    private (double, double) _bestLapTime;
+    public (double, double) BestLapTime
+    {
+        get => _bestLapTime;
+        set => _bestLapTime = value;
+    }
     #endregion
 
     public CsvData()
@@ -327,16 +362,20 @@ public class CsvData
                         _listEthanolInput3.Add(double.Parse(values[28]));
                         _dictLatLon.Add(double.Parse(values[0]), (double.Parse(values[29]), double.Parse(values[30])));
 
-                        if (!previousLapCounter.Equals(values[31]))
+                        if (!previousLapCounter.Equals(values[32]))
                         {
-                            _dictLapData.Add(int.Parse(values[31]), (double.Parse(values[0]), 0.0));
-                            previousLapCounter = values[31];
+                            _dictLapData.Add(int.Parse(values[32]), (double.Parse(values[0]), 0.0));
+                            previousLapCounter = values[32];
 
                             // TODO - fix this hack
                             // Default first one to 0.1 hertz start, works better with the chart
                             if (_dictLapData.Count == 1)
                                 _dictLapData[0] = (0.1, 0.0);
                         }
+
+                        _listSessionStartTimeMs.Add(double.Parse(values[31]));
+                        _listLapIndex.Add(double.Parse(values[32]));
+                        _listLapStartTimeMs.Add(double.Parse(values[33]));
                     }
                     catch (Exception ex)
                     {

--- a/WT-DataAnalysis-DatalogReview/Views/DatalogReviewView.cs
+++ b/WT-DataAnalysis-DatalogReview/Views/DatalogReviewView.cs
@@ -57,6 +57,7 @@ public partial class DatalogReviewView : UserControl
     {
         SplitContainer spl_Left = Controls.Find("spl_Left_DatalogReivew", true).FirstOrDefault() as SplitContainer;
 
+        #region Left Split - Panel 1
         #region DataGridView - All values at cursor point
         DataGridView dgv_AllValues = new()
         {
@@ -138,6 +139,16 @@ public partial class DatalogReviewView : UserControl
         };
         grp_Gear.Controls.Add(lbl_Gear);
         spl_Left.Panel1.Controls.Add(grp_Gear);
+        #endregion
+
+        #region Left Split - Panel 2
+        Chart chartTrackMap = new()
+        {
+            Name = "chart_TrackMap"
+        };
+
+        spl_Left.Panel2.Controls.Add(chartTrackMap);
+        #endregion
     }
 
     private static void DataGridView_ResizeToFitAllRows(DataGridView dgv)
@@ -317,19 +328,6 @@ public partial class DatalogReviewView : UserControl
             chart.Series.RemoveAt(0);
         while (chart.Legends.Count > 0)
             chart.Legends.RemoveAt(0);
-
-        Chart chartTrackMap = new()
-        {
-            Name = "chart_TrackMap"
-        };
-        var spl_Left = Controls.Find("spl_Left_DatalogReivew", true).FirstOrDefault() as SplitContainer;
-        spl_Left.Panel2.Controls.Add(chartTrackMap);
-
-        if (chartTrackMap.Series.Any(x => x.Name == "DataMarker"))
-        {
-            Series removeSeries = chartTrackMap.Series[1];
-            chartTrackMap.Series.Remove(removeSeries);
-        }
 
 
         double[] GetRelevantDataForThisHertzRange(double[] fullList)
@@ -555,6 +553,12 @@ public partial class DatalogReviewView : UserControl
         Chart chartTrackMap = Controls.Find("chart_TrackMap", true).FirstOrDefault() as Chart;
         if (chartTrackMap == null) return;
 
+        if (chartTrackMap.Series.Any(x => x.Name == "DataMarker"))
+        {
+            Series removeSeries = chartTrackMap.Series[1];
+            chartTrackMap.Series.Remove(removeSeries);
+        }
+
         ChartArea chartAreaTrackMap = new("ChartAreaTrackMap");
 
         CurrentTrackCoords trackMapMaxCoords = TrackData.GetTrackMapMaxCoords(_csvData.Track);
@@ -562,6 +566,9 @@ public partial class DatalogReviewView : UserControl
         chartAreaTrackMap.AxisX.Maximum = trackMapMaxCoords.LatMax;
         chartAreaTrackMap.AxisY.Minimum = trackMapMaxCoords.LonMin;
         chartAreaTrackMap.AxisY.Maximum = trackMapMaxCoords.LonMax;
+
+        //chartAreaTrackMap.AxisX.Interval = 10;
+        //chartAreaTrackMap.AxisY.Interval = 10;
 
         chartAreaTrackMap.Position.Height = 100;
         chartAreaTrackMap.Position.Width = 100;

--- a/WT-DataAnalysis-DatalogReview/Views/DatalogReviewView.cs
+++ b/WT-DataAnalysis-DatalogReview/Views/DatalogReviewView.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Windows.Forms.DataVisualization.Charting;
+﻿using System.Windows.Forms.DataVisualization.Charting;
 using WT_DataAnalysis_DatalogReview.CustomFormComponents;
 using WT_DataAnalysis_DatalogReview.Models;
 using WT_DataAnalysis_DatalogReview.Utils;
@@ -676,20 +675,28 @@ public partial class DatalogReviewView : UserControl
             // Lap Timing Data
             if (Controls.Find("spl_Left_DatalogReivew", true).FirstOrDefault() is SplitContainer spl_Left)
             {
-                double currentLapIndex = _csvData.GetDataValueCurrentValue((int)DataValues.LapIndex - 1, hertzIndex); 
+                double currentLapIndex = _csvData.GetDataValueCurrentValue((int)DataValues.LapIndex - 1, hertzIndex);
+
                 double elapsedLapTime = _csvData.GetDataValueCurrentValue((int)DataValues.SessionStartTimeMs - 1, hertzIndex) -
-                                        _csvData.GetDataValueCurrentValue((int)DataValues.LapStartTimeMs - 1, hertzIndex);
+                                            _csvData.GetDataValueCurrentValue((int)DataValues.LapStartTimeMs - 1, hertzIndex);
                 double currentLapTime = _csvData.DictLapTimes[currentLapIndex];
                 double previousLapTime = currentLapIndex != 0 ? _csvData.DictLapTimes[currentLapIndex - 1] : 0;
+
+                string strCurrentLapIndex;
+                if (currentLapIndex == 0)
+                    strCurrentLapIndex = "Out Lap";
+                else if (currentLapIndex == _csvData.DictLapTimes.Count - 1)
+                    strCurrentLapIndex = "In Lap";
+                else
+                    strCurrentLapIndex = currentLapIndex.ToString();
 
                 spl_Left.Panel1.Controls["VD_Panel_ElapsedLapTime:"].Controls["LabelValue"].Text = TimeSpan.FromMilliseconds(elapsedLapTime).ToString(@"m\:ss\:fff");
                 spl_Left.Panel1.Controls["VD_Panel_CurrentLapTime:"].Controls["LabelValue"].Text = TimeSpan.FromMilliseconds(currentLapTime).ToString(@"m\:ss\:fff");
                 spl_Left.Panel1.Controls["VD_Panel_PreviousLapTime:"].Controls["LabelValue"].Text = TimeSpan.FromMilliseconds(previousLapTime).ToString(@"m\:ss\:fff");
                 spl_Left.Panel1.Controls["VD_Panel_BestLapTime:"].Controls["LabelValue"].Text = TimeSpan.FromMilliseconds(_csvData.BestLapTime.Item2).ToString(@"m\:ss\:fff");
                 spl_Left.Panel1.Controls["VD_Panel_PbLapTime:"].Controls["LabelValue"].Text = TimeSpan.FromMilliseconds(_csvData.BestLapTime.Item2).ToString(@"m\:ss\:fff");
-                spl_Left.Panel1.Controls["VD_Panel_LapIndex:"].Controls["LabelValue"].Text = currentLapIndex.ToString();
+                spl_Left.Panel1.Controls["VD_Panel_LapIndex:"].Controls["LabelValue"].Text = strCurrentLapIndex;
             }
-
 
             {
                 DataPoint matchingPoint = chart.Series[0].Points.FirstOrDefault(x => x.XValue == Math.Round(xValue, 1));


### PR DESCRIPTION
Refactor the lap timing with how we send through the GPS data and timing data from client, instead of sending all lap data we only send an overall session time, lap index and lap time as the raw data. The derived data like current lap, best lap, pb lap etc is calculated on the go.

Also refactored a lunch of logic in Data Analysis to suit improved ways in Live Telemetry.